### PR TITLE
Add guards to the cilktc header files and revert Dockerfile to include entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV PERL5LIB="/root/.opam/system/lib/perl5"
 ENV OCAML_TOPLEVEL_PATH="/root/.opam/system/lib/toplevel"
 ENV PATH="/root/.opam/system/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-WORKDIR /opt/ktc/bin
+WORKDIR /src
 
-#ENTRYPOINT [ "/opt/ktc/bin/ktc" ]
-#CMD [ "--help" ]
+ENTRYPOINT [ "/opt/ktc/bin/ktc" ]
+CMD [ "--help" ]

--- a/include/cilktc-free.h
+++ b/include/cilktc-free.h
@@ -1,3 +1,5 @@
+/* Pragma once instead of #ifndef + #define guards. */
+#pragma once
 
 #include <stdint.h>
 #include <setjmp.h>

--- a/include/cilktc-mist.h
+++ b/include/cilktc-mist.h
@@ -1,3 +1,5 @@
+/* Pragma once instead of #ifndef + #define guards. */
+#pragma once
 
 #include <stdint.h>
 #include <setjmp.h>

--- a/include/cilktc.h
+++ b/include/cilktc.h
@@ -1,3 +1,5 @@
+/* Pragma once instead of #ifndef + #define guards. */
+#pragma once
 
 #include <stdio.h>
 #include <stdint.h>


### PR DESCRIPTION
Added guards to the cilktc header files to avoid compilation errors if at some point in the code these headers would get included twice. Used pragma guards instead of `#ifndef` + `#define` as `#pragma once` is used in include/ktcpipe.h