### PR TITLE
Remove the WDT_start define

### DIFF
--- a/include/cilktc-free.h
+++ b/include/cilktc-free.h
@@ -73,7 +73,7 @@ typedef void * xQueueHandle;
 //#define aperiodic(x, ms)  printf("");sdelay(x, ms); int i =0; while(i){sdelay(0, ms);} printf("aperiodic\n")
 void ktc_fdelay();
 #define fdelay(val, unit) ktc_fdelay()
-#define WDT_start()  WDT_start();vTaskStartScheduler();
+//#define WDT_start()  WDT_start();vTaskStartScheduler();
 extern int period;
 extern int deadline;
 extern int runtime;

--- a/include/cilktc-mist.h
+++ b/include/cilktc-mist.h
@@ -75,7 +75,7 @@ typedef void * xQueueHandle;
 //#define aperiodic(x, ms)  printf("");sdelay(x, ms); int i =0; while(i){sdelay(0, ms);} printf("aperiodic\n")
 void ktc_fdelay();
 #define fdelay(val, unit) ktc_fdelay()
-#define WDT_start()  WDT_start();vTaskStartScheduler();
+//#define WDT_start()  WDT_start();vTaskStartScheduler();
 extern int period;
 extern int deadline;
 extern int runtime;


### PR DESCRIPTION
Remove the WDT_start defines from the headers `cilktc-free.h` and `cilktc-mist.h`. Including one of these headers before including the FreeRTOS headers which declare `void WDT_start()` will cause KTC to give a syntax error.