### PR TITLE
Allow the docker to be used without running ktc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ ENV PERL5LIB="/root/.opam/system/lib/perl5"
 ENV OCAML_TOPLEVEL_PATH="/root/.opam/system/lib/toplevel"
 ENV PATH="/root/.opam/system/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
+RUN ln -s /opt/ktc/bin/ktc /usr/bin/ktc
+
 WORKDIR /src
 
-ENTRYPOINT [ "/opt/ktc/bin/ktc" ]
-CMD [ "--help" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This removes the default behavior of setting an executable as the entrypoint and `--help` as default command. Instead this launches a shell that can be used for to run a sequence of commands where KTC is needed, such as in a CI script. This also adds a symlink to ktc such that it is accessible anywhere in the docker.

The old behavior from the old Dockerfile can still be accessed through the following command:
```sh
docker run -it --rm ktc:latest ktc --help
```